### PR TITLE
Adding switch for enabling occlusions for the uvdar plugin

### DIFF
--- a/models/mrs_robots_description/urdf/component_snippets.xacro
+++ b/models/mrs_robots_description/urdf/component_snippets.xacro
@@ -1992,7 +1992,7 @@ limitations under the License.
 
   <!-- Macro to add a UV Camera {-->
   <xacro:macro name="uvcam_macro"
-    params="calibration_file frame_rate number namespace parent_link camera_publish_topic *origin">
+    params="calibration_file occlusions frame_rate number namespace parent_link camera_publish_topic *origin">
     <link name="${namespace}_uvcam_${number}_link">
       <gravity>0</gravity>
       <visual>
@@ -2014,7 +2014,7 @@ limitations under the License.
         <plugin name='${namespace}_uvcam_${number}' filename="libuvdar_cam.so">
           <alwaysOn>false</alwaysOn>
           <updateRate>${frame_rate}</updateRate>
-          <occlusion>false</occlusion>
+          <occlusion>${occlusions}</occlusion>
           <framerate>${frame_rate}</framerate>
           <calibration_file>${calibration_file}</calibration_file>
           <number>${number}</number>

--- a/models/mrs_robots_description/urdf/f450.xacro
+++ b/models/mrs_robots_description/urdf/f450.xacro
@@ -1061,7 +1061,8 @@
       number="1"          
       frame_rate="80"     
       camera_publish_topic="/${namespace}/uvdar_bluefox_left/image_raw"
-      calibration_file="$(arg uvcam_calib_file)">
+      calibration_file="$(arg uvcam_calib_file)"
+      occlusions="$(arg uvcam_occlusions)">
     <origin xyz="0.037 0.1175 0.05" rpy="0 0 ${rad70}" />
     </xacro:uvcam_macro>  
 
@@ -1071,7 +1072,8 @@
       number="2"          
       frame_rate="80"     
       camera_publish_topic="/${namespace}/uvdar_bluefox_right/image_raw"
-      calibration_file="$(arg uvcam_calib_file)">
+      calibration_file="$(arg uvcam_calib_file)"
+      occlusions="$(arg uvcam_occlusions)">
     <origin xyz="0.037 -0.1175 0.05" rpy="0 0 -${rad70}" />
     </xacro:uvcam_macro>  
 

--- a/scripts/simulation/__init__.py
+++ b/scripts/simulation/__init__.py
@@ -240,6 +240,7 @@ def spawn_model(
         uvled_beacon_f=30,
         enable_uv_camera=False, 
         uvcam_calib_file="~/calib_results.txt",
+        uvcam_occlusions=False,
         debug=False
     ):
     x, y, z, yaw = pose
@@ -312,6 +313,7 @@ def spawn_model(
 
     kwargs['mappings']['enable_uv_camera'] = "true" if enable_uv_camera else "false"
     kwargs['mappings']['uvcam_calib_file'] = uvcam_calib_file
+    kwargs['mappings']['uvcam_occlusions'] = "true" if uvcam_occlusions else "false"
 
     # ros commandline arguments
     kwargs['mappings']['mrs_robots_description_dir'] = model_pathname

--- a/scripts/simulation/spawn.py
+++ b/scripts/simulation/spawn.py
@@ -188,6 +188,9 @@ def spawn():
     parser.add_argument(
         '--uv-camera-calibration-file', nargs=1, type=str, default=("~/.ros/calib_results.txt"),
         help='Specify UV camera calibration different than default one')
+    parser.add_argument(
+        '--enable-uv-occlusions', action = 'store_true',
+        help='Enable occlusions for UVDAR simulation - heavy on computation (default: false)')
     mbzirc_group = parser.add_mutually_exclusive_group()
     mbzirc_group.add_argument(
         '--wall-challenge', action = 'store_true',
@@ -339,6 +342,7 @@ def spawn():
             uvled_beacon_f = "{}".format(uvled_beacon_fr[0]),
             enable_uv_camera = args.enable_uv_camera,
             uvcam_calib_file = uvcam_calib[0].strip(),
+            uvcam_occlusions = args.enable_uv_occlusions,
             debug=args.debug)
 
         if args.generate_launch_file or args.run:

--- a/scripts/simulation/spawn.py
+++ b/scripts/simulation/spawn.py
@@ -189,7 +189,7 @@ def spawn():
         '--uv-camera-calibration-file', nargs=1, type=str, default=("~/.ros/calib_results.txt"),
         help='Specify UV camera calibration different than default one')
     parser.add_argument(
-        '--enable-uv-occlusions', action = 'store_true',
+        '--use-uv-occlusions', action = 'store_true',
         help='Enable occlusions for UVDAR simulation - heavy on computation (default: false)')
     mbzirc_group = parser.add_mutually_exclusive_group()
     mbzirc_group.add_argument(
@@ -342,7 +342,7 @@ def spawn():
             uvled_beacon_f = "{}".format(uvled_beacon_fr[0]),
             enable_uv_camera = args.enable_uv_camera,
             uvcam_calib_file = uvcam_calib[0].strip(),
-            uvcam_occlusions = args.enable_uv_occlusions,
+            uvcam_occlusions = args.use_uv_occlusions,
             debug=args.debug)
 
         if args.generate_launch_file or args.run:


### PR DESCRIPTION
Added a switch for easier enabling of occlusions for UV LEDs. If UVDAR camera is enabled, adding `--enable-uv-occlusions`. This is currently specifically set for our f450 UAVs.